### PR TITLE
Remove unicode to string conversion. Add test for unicode handling

### DIFF
--- a/pygenie/jobs/utils.py
+++ b/pygenie/jobs/utils.py
@@ -225,8 +225,6 @@ def is_file(path):
 
     path = convert_to_unicode(path)
 
-    if sys.version_info < (3,):
-        path = path.encode('utf-8')
     return path is not None and \
         (os.path.isfile(path) \
          or path.startswith('s3://') \

--- a/tests/job_tests/test_prestojob.py
+++ b/tests/job_tests/test_prestojob.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
@@ -427,4 +429,15 @@ class TestingPrestoJobAdapters(unittest.TestCase):
                 u'user': u'jpresto',
                 u'version': u'0.0.1presto'
             }
+        )
+
+    def test_unicode_script(self):
+        """Test PrestoJob containing unicode script."""
+
+        job = pygenie.jobs.PrestoJob() \
+            .script(u'SELECT \'Siła_wyższa_(serial_telewizyjny)\'') \
+
+        assert_equals(
+            job.cmd_args,
+            u'-f script.presto'
         )


### PR DESCRIPTION
- Remove Unicode to String conversion since query text could potentially have Unicode
- Added to test to ensure Unicode handled correctly
- python2/3 compatible 

