### PR TITLE
get rid of magic number for cluster tag mapping

### DIFF
--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -133,6 +133,8 @@ class Repr(object):
 class GenieJob(object):
     """Base Genie job."""
 
+    DEFAULT_CLUSTER_TAG = 99999
+
     def __init__(self, conf=None):
         assert conf is None or isinstance(conf, GenieConf), \
             "invalid conf '{}', should be None or GenieConf".format(conf)
@@ -179,7 +181,7 @@ class GenieJob(object):
         self.repr_obj.append('genie_username', (self._username,))
 
         #initialize cluster tags with default set of tags
-        self._cluster_tag_mapping[99999] = self.default_cluster_tags
+        self._cluster_tag_mapping[GenieJob.DEFAULT_CLUSTER_TAG] = self.default_cluster_tags
 
     def __repr__(self):
         return self.__unicode__()


### PR DESCRIPTION
Internally we use the default tag to handle Presto changes for data tags.  This change will allow us to release kragle internally with a check for correct behavior.