### PR TITLE
do not set Range header for initial call to get stderr

### DIFF
--- a/pygenie/jobs/running.py
+++ b/pygenie/jobs/running.py
@@ -527,15 +527,14 @@ class RunningJob(object):
         stderr_part = ''
 
         if self.__reload_stderr:
-            range_start = 0 if self._cached_stderr is None else len(self._cached_stderr)
+            headers = {'Range': 'bytes={}-'.format(len(self._cached_stderr))} \
+                if self._cached_stderr else None
 
-            logger.debug('getting stderr (Range: bytes=%s-', range_start)
+            logger.debug('getting stderr (headers -> %s)', headers)
 
             stderr_part = self._adapter.get_stderr(
                 self._job_id,
-                headers={
-                    'Range': 'bytes={}-'.format(range_start)
-                },
+                headers=headers,
                 **kwargs
             )
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.4.2',
+    version='3.4.3',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',


### PR DESCRIPTION
When stderr log file is 0 bytes and client sends a request with a Range header, server returns an error. This PR only adds the Range header when the cached stderr is not None or 0 bytes.