### PR TITLE
Break if there's no pages for cluster jobs.

### DIFF
--- a/pygenie/client.py
+++ b/pygenie/client.py
@@ -1636,7 +1636,7 @@ class Genie(object):
 
 
             # Break if we're at the end
-            if (resp['page']['totalPages']) == (resp['page']['number'] + 1):
+            if (resp['page']['totalPages']) <= (resp['page']['number'] + 1):
                 break
 
             # On to the next iteration

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.4.3',
+    version='3.4.4',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',


### PR DESCRIPTION
This comparison should be using the `<=` operator like the rest of the client library, or else we spin our wheels if there's never been a job run on the cluster.