### PR TITLE
Add mocked builtin methods to fix copy and pickle for GenieConf* classes.

### DIFF
--- a/pygenie/conf.py
+++ b/pygenie/conf.py
@@ -45,6 +45,7 @@ class GenieConfSection(object):
         self.__name = name
 
     def __getattr__(self, attr):
+        if attr.startswith('__'): raise AttributeError
         if attr not in self.to_dict():
             env = self.__get_env(attr)
             if env is not None:
@@ -137,6 +138,7 @@ class GenieConf(object):
             self._load_options()
 
     def __getattr__(self, attr):
+        if attr.startswith('__'): raise AttributeError
         if attr not in self.to_dict():
             return GenieConfSection(attr)
         return self.to_dict().get(attr)

--- a/pygenie/conf.py
+++ b/pygenie/conf.py
@@ -54,17 +54,21 @@ class GenieConfSection(object):
                 .format(attr, self.__name, sorted(self.to_dict().keys())))
         return self.to_dict().get(attr)
 
+    # Fix issues copying: https://bugs.python.org/issue19364
     def __copy__(self):
         g = GenieConfSection(self.__name)
         for k,v in self.to_dict().iteritems():
             g.set(k,v)
         return g
-
     def __deepcopy__(self, memo=False):
         g = GenieConfSection(copy(self.__name))
         for k,v in self.to_dict().iteritems():
             g.set(copy(k), copy(v))
         return g
+
+    # Fix issues pickling: https://stackoverflow.com/questions/2049849/why-cant-i-pickle-this-object
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): self.__dict__.update(d)
 
     def __get_env(self, attr):
         return os.environ.get('{}_{}'.format(self.__name, attr))
@@ -137,6 +141,7 @@ class GenieConf(object):
             return GenieConfSection(attr)
         return self.to_dict().get(attr)
 
+    # Fix issues copying: https://bugs.python.org/issue19364
     def __copy__(self):
         g = GenieConf()
         for k,v in self.to_dict().iteritems():
@@ -147,9 +152,12 @@ class GenieConf(object):
             else:
                 g.setattr(copy(k), copy(v))
         return g
-
     def __deepcopy__(self, memo=False):
         return self.__copy__()
+
+    # Fix issues pickling: https://stackoverflow.com/questions/2049849/why-cant-i-pickle-this-object
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): self.__dict__.update(d)
 
     def __repr__(self):
         return '.'.join(['{}()'.format(self.__class__.__name__)] + \


### PR DESCRIPTION
Fixes https://bugs.python.org/issue19364

Tests:
```
In [2]: import pygenie

In [3]: g = pygenie.conf.GenieConf()

In [4]: g.__copy__()
Out[4]: GenieConf()

In [5]: g.__deepcopy__()
Out[5]: GenieConf()
```