### PR TITLE
adding Genie group and grouping instance

### DIFF
--- a/pygenie/adapter/genie_3.py
+++ b/pygenie/adapter/genie_3.py
@@ -201,6 +201,8 @@ class Genie3Adapter(GenieBaseAdapter):
             payload['grouping'] = job.get('genie_grouping')
         if job.get('genie_grouping_instance'):
             payload['groupingInstance'] = job.get('genie_grouping_instance')
+        if job.get('metadata'):
+            payload['metadata'] = job.get('metadata')
 
         return payload
 
@@ -287,6 +289,7 @@ class Genie3Adapter(GenieBaseAdapter):
             ret['job_link'] = job_link
             ret['json_link'] = link
             ret['kill_uri'] = link
+            ret['metadata'] = data.get('metadata') or dict()
             ret['name'] = data.get('name')
             ret['output_uri'] = output_link
             ret['started'] = data.get('started')

--- a/pygenie/adapter/genie_3.py
+++ b/pygenie/adapter/genie_3.py
@@ -197,6 +197,10 @@ class Genie3Adapter(GenieBaseAdapter):
             payload['cpu'] = job.get('genie_cpu')
         if job.get('genie_memory'):
             payload['memory'] = job.get('genie_memory')
+        if job.get('genie_grouping'):
+            payload['grouping'] = job.get('genie_grouping')
+        if job.get('genie_grouping_instance'):
+            payload['groupingInstance'] = job.get('genie_grouping_instance')
 
         return payload
 
@@ -277,6 +281,8 @@ class Genie3Adapter(GenieBaseAdapter):
             ret['created'] = data.get('created')
             ret['description'] = data.get('description')
             ret['finished'] = data.get('finished')
+            ret['genie_grouping'] = data.get('grouping')
+            ret['genie_grouping_instance'] = data.get('groupingInstance')
             ret['id'] = data.get('id')
             ret['job_link'] = job_link
             ret['json_link'] = link

--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -172,6 +172,7 @@ class GenieJob(object):
         self._job_id = uuid_str()
         self._job_name = None
         self._job_version = 'NA'
+        self._metadata = None
         self._parameters = OrderedDict()
         self._post_cmd_args = list()
         self._setup_file = None
@@ -831,6 +832,31 @@ class GenieJob(object):
         Returns:
             :py:class:`GenieJob`: self
         """
+
+    @unicodify
+    @add_to_repr('append')
+    def metadata(self, **kwargs):
+        """
+        Sets the metadata for the job (a dict).
+
+        Example:
+            >>> job = GenieJob() \\
+            ...     .metadata(source='service') \\
+            ...     .metadata(job_type='GenieJob')
+
+        Args:
+            **kwargs: Key/value for the metadata mapping.
+
+        Returns:
+            :py:class:`GenieJob`: self
+        """
+
+        if self._metadata is None:
+            self._metadata = kwargs
+        else:
+            self._metadata.update(kwargs)
+
+        return self
 
     @unicodify
     @add_to_repr('append')

--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -165,6 +165,8 @@ class GenieJob(object):
         self._description = None
         self._email = None
         self._genie_cpu = None
+        self._genie_grouping = None
+        self._genie_grouping_instance = None
         self._genie_memory = None
         self._group = None
         self._job_id = uuid_str()
@@ -552,6 +554,48 @@ class GenieJob(object):
         # TODO: for legacy support (need to remove) - should use .genie_timeout()
         logger.warning("Use .genie_email('%s') to set Genie email.", email)
         return self.genie_email(email)
+
+    @unicodify
+    @arg_string
+    @add_to_repr('overwrite')
+    def genie_grouping(self, _genie_grouping):
+        """
+        Set the Genie grouping of the job relative to other jobs
+        (e.g. scheduler job name).
+
+        Example:
+            >>> job = GenieJob() \\
+            ...     .genie_grouping('MY.JOB.TEST_1')
+
+        Args:
+             genie_grouping (str): The grouping name.
+
+        Returns:
+            :py:class:`GenieJob`: self
+        """
+
+    @unicodify
+    @arg_string
+    @add_to_repr('overwrite')
+    def genie_grouping_instance(self, _genie_grouping_instance):
+        """
+        Set the Genie grouping instance of the job relative to other jobs
+        (e.g. scheduler job run).
+
+        Example:
+            >>> job = GenieJob() \\
+            ...     .genie_grouping('MY.JOB.TEST_1') \\
+            ...     .genie_grouping_instance('11')
+            >>> job = GenieJob() \\
+            ...     .genie_grouping('MY.JOB.TEST_1') \\
+            ...     .genie_grouping_instance('12')
+
+        Args:
+             genie_grouping_instance (str): The grouping instance.
+
+        Returns:
+            :py:class:`GenieJob`: self
+        """
 
     @add_to_repr('overwrite')
     def genie_memory(self, memory):

--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -750,6 +750,8 @@ class GenieJob(object):
             :py:class:`GenieJob`: self
         """
 
+        assert _job_id is not None and _job_id != '', "job id cannot be '' or None"
+
     @unicodify
     @arg_string
     @add_to_repr('overwrite')

--- a/pygenie/jobs/running.py
+++ b/pygenie/jobs/running.py
@@ -272,6 +272,34 @@ class RunningJob(object):
 
         return self.__convert_dttm_to_epoch('finished')
 
+    @property
+    @get_from_info('genie_grouping', info_section='job')
+    def genie_grouping(self):
+        """
+        Get the Genie grouping for the job.
+
+        Example:
+            >>> running_job.genie_grouping
+            'test_group'
+
+        Returns:
+            str: The Genie grouping.
+        """
+
+    @property
+    @get_from_info('genie_grouping_instance', info_section='job')
+    def genie_grouping_instance(self):
+        """
+        Get the Genie grouping instance for the job.
+
+        Example:
+            >>> running_job.genie_grouping_instance
+            'test_group.1234'
+
+        Returns:
+            str: The Genie grouping instance.
+        """
+
     def genie_log(self, iterator=False, **kwargs):
         """
         Get the job's Genie log as either an iterator or full text.

--- a/pygenie/jobs/running.py
+++ b/pygenie/jobs/running.py
@@ -485,6 +485,20 @@ class RunningJob(object):
         return self.request_data.get('memory')
 
     @property
+    @get_from_info('metadata', info_section='job')
+    def metadata(self):
+        """
+        Get the job's metadata.
+
+        Example:
+            >>> running_job.metadata
+            {"scheduler": "cron"}
+
+        Returns:
+            dict: Metadata mapping.
+        """
+
+    @property
     @get_from_info('output_uri', info_section='job')
     def output_uri(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.4.11',
+    version='3.5.0',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',

--- a/tests/job_tests/test_geniejob.py
+++ b/tests/job_tests/test_geniejob.py
@@ -384,3 +384,99 @@ class TestingSetGenieUrl(unittest.TestCase):
             url_clean,
             job._conf.genie.url
         )
+
+
+@patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
+class TestingGrouping(unittest.TestCase):
+    """Test job Genie grouping."""
+
+    def test_grouping_repr(self):
+        """Test job Genie grouping repr."""
+
+        job = pygenie.jobs.GenieJob() \
+            .job_id('1234') \
+            .genie_username('group_repr') \
+            .genie_grouping('test_group_repr_1') \
+            .genie_grouping('test_group_repr_2')
+
+        assert_equals(
+           '.'.join([
+                'GenieJob()',
+                'genie_grouping("test_group_repr_2")',
+                'genie_username("group_repr")',
+                'job_id("1234")',
+            ]),
+            str(job)
+        )
+
+    def test_setting_grouping(self):
+        """Test setting job Genie grouping."""
+
+        job = pygenie.jobs.GenieJob() \
+            .genie_grouping('test_group') \
+            .genie_grouping('test_group_1')
+
+        assert_equals(
+            'test_group_1',
+            job._genie_grouping
+        )
+
+    def test_grouping_payload_genie3(self):
+        """Test job Genie grouping payload (Genie 3)."""
+
+        job = pygenie.jobs.GenieJob() \
+            .command_arguments('test') \
+            .genie_grouping('test_grouping_payload') \
+
+        assert_equals(
+            'test_grouping_payload',
+            pygenie.adapter.genie_3.get_payload(job)['grouping']
+        )
+
+
+@patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
+class TestingGroupingInstance(unittest.TestCase):
+    """Test job Genie grouping instance."""
+
+    def test_grouping_instance_repr(self):
+        """Test job Genie grouping instance repr."""
+
+        job = pygenie.jobs.GenieJob() \
+            .job_id('1234') \
+            .genie_username('group_instance_repr') \
+            .genie_grouping_instance('test_group_instance_repr_1') \
+            .genie_grouping_instance('test_group_instance_repr_2') \
+
+        assert_equals(
+           '.'.join([
+                'GenieJob()',
+                'genie_grouping_instance("test_group_instance_repr_2")',
+                'genie_username("group_instance_repr")',
+                'job_id("1234")',
+            ]),
+            str(job)
+        )
+
+    def test_setting_grouping_instance(self):
+        """Test setting job Genie grouping instance."""
+
+        job = pygenie.jobs.GenieJob() \
+            .genie_grouping_instance('test_group_1234') \
+            .genie_grouping_instance('test_group_777')
+
+        assert_equals(
+            'test_group_777',
+            job._genie_grouping_instance
+        )
+
+    def test_grouping_instance_payload_genie3(self):
+        """Test job Genie grouping instance payload (Genie 3)."""
+
+        job = pygenie.jobs.GenieJob() \
+            .command_arguments('test') \
+            .genie_grouping_instance('test_grouping_instance_payload') \
+
+        assert_equals(
+            'test_grouping_instance_payload',
+            pygenie.adapter.genie_3.get_payload(job)['groupingInstance']
+        )

--- a/tests/job_tests/test_geniejob.py
+++ b/tests/job_tests/test_geniejob.py
@@ -302,6 +302,32 @@ class TestingJobExecute(unittest.TestCase):
         assert_equals(new_job_id, job._job_id)
 
 
+@patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
+class TestingSetJobId(unittest.TestCase):
+    """Test setting job id."""
+
+    def test_job_id_empty_string(self):
+        """Test setting job id empty string ('')."""
+
+        with assert_raises(AssertionError) as cm:
+            job = pygenie.jobs.GenieJob().job_id('')
+
+    def test_job_id_none(self):
+        """Test setting job id None."""
+
+        with assert_raises(AssertionError) as cm:
+            job = pygenie.jobs.GenieJob().job_id(None)
+
+    def test_job_id(self):
+        """Test setting job id."""
+
+        job = pygenie.jobs.GenieJob().job_id('job-id-1234')
+
+        assert_equals(
+            'job-id-1234',
+            job._job_id
+        )
+
 
 @patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
 class TestingSetJobName(unittest.TestCase):

--- a/tests/job_tests/test_geniejob.py
+++ b/tests/job_tests/test_geniejob.py
@@ -448,7 +448,7 @@ class TestingGroupingInstance(unittest.TestCase):
             .genie_grouping_instance('test_group_instance_repr_2') \
 
         assert_equals(
-           '.'.join([
+            '.'.join([
                 'GenieJob()',
                 'genie_grouping_instance("test_group_instance_repr_2")',
                 'genie_username("group_instance_repr")',
@@ -479,4 +479,69 @@ class TestingGroupingInstance(unittest.TestCase):
         assert_equals(
             'test_grouping_instance_payload',
             pygenie.adapter.genie_3.get_payload(job)['groupingInstance']
+        )
+
+
+@patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
+class TestingMetadata(unittest.TestCase):
+    """Test job metadata."""
+
+    def test_metadata_repr(self):
+        """Test job metadata repr."""
+
+        job = pygenie.jobs.GenieJob() \
+            .job_id('1234') \
+            .genie_username('test_metadata_repr') \
+            .metadata(foo='fizz') \
+            .metadata(foo='foo') \
+            .metadata(bar='buzz') \
+            .metadata(hello='hi') \
+
+        assert_equals(
+            '.'.join([
+                'GenieJob()',
+                'genie_username("test_metadata_repr")',
+                'job_id("1234")',
+                'metadata(bar="buzz")',
+                'metadata(foo="fizz")',
+                'metadata(foo="foo")',
+                'metadata(hello="hi")'
+            ]),
+            str(job)
+        )
+
+    def test_setting_metadata(self):
+        """Test setting job metadata."""
+
+        job = pygenie.jobs.GenieJob() \
+            .metadata(key1='val1') \
+            .metadata(key2='val2') \
+            .metadata(key3='val3') \
+            .metadata(key1='val1a') \
+            .metadata(key4='val4', key5='val5')
+
+        assert_equals(
+            {
+                'key1': 'val1a',
+                'key2': 'val2',
+                'key3': 'val3',
+                'key4': 'val4',
+                'key5': 'val5',
+            },
+            job._metadata
+        )
+
+    def test_metadata_payload_genie3(self):
+        """Test job metadata payload (Genie 3)."""
+
+        job = pygenie.jobs.GenieJob() \
+            .command_arguments('test') \
+            .metadata(k1=1, k2=2)
+
+        assert_equals(
+            {
+                'k1': 1,
+                'k2': 2,
+            },
+            pygenie.adapter.genie_3.get_payload(job)['metadata']
         )

--- a/tests/job_tests/test_runningjob.py
+++ b/tests/job_tests/test_runningjob.py
@@ -413,6 +413,54 @@ class TestingRunningJobProperties(unittest.TestCase):
             values
         )
 
+    @patch('pygenie.adapter.genie_3.Genie3Adapter.get_status')
+    @patch('pygenie.adapter.genie_3.Genie3Adapter.get_info_for_rj')
+    def test_get_runningjob_genie_grouping(self, get_info, get_status):
+        """Test getting RunningJob.genie_grouping."""
+
+        value = 'test_group'
+
+        get_status.return_value = 'RUNNING'
+        get_info.return_value = {'genie_grouping': value}
+
+        running_job = pygenie.jobs.RunningJob('rj-grouping')
+
+        values = [
+            running_job.genie_grouping,
+            running_job.genie_grouping
+        ]
+
+        get_info.assert_called_once_with('rj-grouping', job=True)
+
+        assert_equals(
+            [value, value],
+            values
+        )
+
+    @patch('pygenie.adapter.genie_3.Genie3Adapter.get_status')
+    @patch('pygenie.adapter.genie_3.Genie3Adapter.get_info_for_rj')
+    def test_get_runningjob_genie_grouping_instance(self, get_info, get_status):
+        """Test getting RunningJob.genie_grouping_instance."""
+
+        value = 'test_group.1234'
+
+        get_status.return_value = 'RUNNING'
+        get_info.return_value = {'genie_grouping_instance': value}
+
+        running_job = pygenie.jobs.RunningJob('rj-grouping-instance')
+
+        values = [
+            running_job.genie_grouping_instance,
+            running_job.genie_grouping_instance
+        ]
+
+        get_info.assert_called_once_with('rj-grouping-instance', job=True)
+
+        assert_equals(
+            [value, value],
+            values
+        )
+
 
 @patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
 class TestingRunningStderr(unittest.TestCase):

--- a/tests/job_tests/test_runningjob.py
+++ b/tests/job_tests/test_runningjob.py
@@ -461,6 +461,30 @@ class TestingRunningJobProperties(unittest.TestCase):
             values
         )
 
+    @patch('pygenie.adapter.genie_3.Genie3Adapter.get_status')
+    @patch('pygenie.adapter.genie_3.Genie3Adapter.get_info_for_rj')
+    def test_get_runningjob_metadata(self, get_info, get_status):
+        """Test getting RunningJob.metadata."""
+
+        value = {"test": "test"}
+
+        get_status.return_value = 'RUNNING'
+        get_info.return_value = {'metadata': value}
+
+        running_job = pygenie.jobs.RunningJob('rj-metadata')
+
+        values = [
+            running_job.metadata,
+            running_job.metadata
+        ]
+
+        get_info.assert_called_once_with('rj-metadata', job=True)
+
+        assert_equals(
+            [value, value],
+            values
+        )
+
 
 @patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
 class TestingRunningStderr(unittest.TestCase):


### PR DESCRIPTION
This PR adds interfaces for setting and getting (from RunningJob) the Genie grouping and grouping instance.

It also includes a small patch for jobs which try to set job id to None or empty string (raises an AssertionError).