### PR TITLE
set Accept headers when getting job info and handle HTTP 500 when getting job info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.5.0',
+    version='3.5.1',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',

--- a/tests/job_tests/test_runningjob.py
+++ b/tests/job_tests/test_runningjob.py
@@ -126,13 +126,13 @@ class TestingRunningJobUpdate(unittest.TestCase):
 
         assert_equals(
             [
-                call('1234-update-timeout', timeout=3),
-                call('1234-update-timeout', path='request', timeout=3),
-                call('1234-update-timeout', if_not_found=[], path='applications', timeout=3),
-                call('1234-update-timeout', if_not_found={}, path='cluster', timeout=3),
-                call('1234-update-timeout', if_not_found={}, path='command', timeout=3),
-                call('1234-update-timeout', if_not_found={}, path='execution', timeout=3),
-                call('1234-update-timeout', if_not_found={}, path='output', timeout=3)
+                call('1234-update-timeout', timeout=3, headers={u'Accept': u'application/json'}),
+                call('1234-update-timeout', path='request', timeout=3, headers={u'Accept': u'application/json'}),
+                call('1234-update-timeout', if_not_found=[], path='applications', timeout=3, headers={u'Accept': u'application/json'}),
+                call('1234-update-timeout', if_not_found={}, path='cluster', timeout=3, headers={u'Accept': u'application/json'}),
+                call('1234-update-timeout', if_not_found={}, path='command', timeout=3, headers={u'Accept': u'application/json'}),
+                call('1234-update-timeout', if_not_found={}, path='execution', timeout=3, headers={u'Accept': u'application/json'}),
+                call('1234-update-timeout', if_not_found={}, path='output', timeout=3, headers={u'Accept': u'application/json'})
             ],
             get.call_args_list
         )
@@ -147,7 +147,7 @@ class TestingRunningJobUpdate(unittest.TestCase):
         running_job.update(info_section='job')
 
         assert_equals(
-            [call(u'1234-update-section', timeout=30)],
+            [call(u'1234-update-section', timeout=30, headers={u'Accept': u'application/json'})],
             get.call_args_list
         )
 
@@ -159,7 +159,7 @@ class TestingRunningJobUpdate(unittest.TestCase):
         running_job.update(info_section='request', timeout=1)
 
         assert_equals(
-            [call('1234-update-section-timeout', path='request', timeout=1)],
+            [call('1234-update-section-timeout', path='request', timeout=1, headers={u'Accept': u'application/json'})],
             get.call_args_list
         )
 


### PR DESCRIPTION
When getting job information from Genie (not output files), set headers to `{"Accept": "application/json"}`.

Also, if after all retries Genie returns a 500, treat like Genie returned a 404 (if `if_not_found` is set return it, otherwise raise `GenieHTTPError(500)`).