### PR TITLE
Handle `is_file` error gracefully

### DIFF
--- a/pygenie/jobs/utils.py
+++ b/pygenie/jobs/utils.py
@@ -224,10 +224,16 @@ def is_file(path):
 
     path = convert_to_unicode(path)
 
-    return path is not None and \
-        (os.path.isfile(path) \
-         or path.startswith('s3://') \
-         or path.startswith('s3n://'))
+    try:
+        return path is not None and \
+            (os.path.isfile(path) \
+            or path.startswith('s3://') \
+            or path.startswith('s3n://'))
+    except (ValueError, TypeError):
+        # Py2 throws TypeError and Py3 ValueError
+        # if os.path.isfile encounters invalid path
+        # ref https://github.com/python/cpython/pull/7695
+        return False
 
 
 def reattach_job(job_id, conf=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,8 @@ from nose.tools import (assert_raises,
 from pygenie.utils import (call,
                            str_to_list)
 from pygenie.jobs.utils import (generate_job_id,
-                                reattach_job)
+                                reattach_job,
+                                is_file)
 
 from pygenie.exceptions import (GenieHTTPError,
                                 GenieJobNotFoundError)
@@ -401,3 +402,12 @@ class TestGeneratingJobId(unittest.TestCase):
         ]
 
         assert_equals(job_id+'-4', generate_job_id(job_id, return_success=False))
+
+    def test_is_file_for_valid_s3path(self):
+        path = 's3://root/myfile'
+        assert_equals(is_file(path), True)
+
+    def test_is_file_for_s3path_with_null_bytes(self):
+        # simulate https://github.com/python/cpython/pull/7695
+        path = 's3://root/myfile\x00'
+        assert_equals(is_file(path), False)


### PR DESCRIPTION
```
from genie.jobs import PrestoJob
rj = PrestoJob().script('select * from dual\x00').execute()
```
For `python2` above code throws
`TypeError: stat() argument 1 must be encoded string without null bytes, not unicode`

and for `python3` it throws

`ValueError: embedded null byte`

The error actually occurs during `os.path.isfile` check [here](https://github.com/Netflix/pygenie/blob/master/pygenie/jobs/presto.py#L68). This PR handles invalid path and returns `False` which should then surface the actual error (if any) in the script itself e.g `Parsing error` for `Presto Engine`.

Additional context -

* Python bug - https://bugs.python.org/issue33721
* Cpython PR - https://github.com/python/cpython/pull/7695