### PR TITLE
Use getfullargspec from inspect module for py3

### DIFF
--- a/pygenie/jobs/utils.py
+++ b/pygenie/jobs/utils.py
@@ -28,6 +28,13 @@ from ..exceptions import GenieJobNotFoundError
 
 logger = logging.getLogger('com.netflix.genie.jobs.utils')
 
+try:
+    getargspec = inspect.getfullargspec
+except AttributeError:
+    # py2 compatible
+    getargspec = inspect.getargspec
+
+
 REPR_APPEND_MODES = {
     'append',
     'insert'
@@ -121,7 +128,7 @@ def arg_list(func):
 
         assert len(args) == 2, 'incorrect arguments to {}()'.format(func.__name__)
 
-        attr_name = inspect.getargspec(func).args[1]
+        attr_name = getargspec(func).args[1]
         self = args[0]
         value = args[1]
 
@@ -156,8 +163,7 @@ def arg_string(func):
         """Set arg to object's attribute as a string."""
 
         assert len(args) == 2, 'incorrect arguments to {}()'.format(func.__name__)
-
-        attr_name = inspect.getargspec(func).args[1]
+        attr_name = getargspec(func).args[1]
         self = args[0]
         value = args[1]
 


### PR DESCRIPTION
Fix deprecation warning to avoid clutter and [switch](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) to the recommend [method](https://bugs.python.org/issue20438). 

```
pygenie/jobs/utils.py:160: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
```