### PR TITLE
Improve presto semicolon logic

### DIFF
--- a/pygenie/jobs/presto.py
+++ b/pygenie/jobs/presto.py
@@ -70,7 +70,8 @@ class PrestoJob(GenieJob):
             self._add_dependency(self._script)
         elif self._script is not None:
             if not self._script.strip().endswith(';'):
-                self._script = '{};'.format(self._script)
+                #\n ensures if the script ends with a comment ; still gets applied
+                self._script = '{}\n;'.format(self._script)
             self._add_dependency({'name': filename, 'data': self._script})
 
         options_str = ' '.join([

--- a/tests/job_tests/test_prestojob.py
+++ b/tests/job_tests/test_prestojob.py
@@ -242,7 +242,7 @@ class TestingPrestoJobAdapters(unittest.TestCase):
                 u'attachments': [
                     {u'name': u'prestofile1', u'data': u'file contents'},
                     {u'name': u'prestofile2', u'data': u'file contents'},
-                    {u'name': u'script.presto', u'data': u'SELECT * FROM DUAL;'}
+                    {u'name': u'script.presto', u'data': u'SELECT * FROM DUAL\n;'}
                 ],
                 u'clusterCriterias': [
                     {u'tags': [u'type:prestocluster1']},
@@ -351,7 +351,7 @@ class TestingPrestoJobAdapters(unittest.TestCase):
                 u'attachments': [
                     (u'prestofile1', u"open file '/prestofile1'"),
                     (u'prestofile2', u"open file '/prestofile2'"),
-                    (u'script.presto', u'SELECT * FROM DUAL;')
+                    (u'script.presto', u'SELECT * FROM DUAL\n;')
                 ],
                 u'clusterCriterias': [
                     {u'tags': [u'type:prestocluster1']},


### PR DESCRIPTION
* [Currently](https://github.com/Netflix/pygenie/blob/master/pygenie/jobs/presto.py#L73), for presto jobs we check if the script/SQL provided by the user ends with a `;` or not. And if not we insert `;` at the end. 
* Above behavior causes issues if the last line of the script is commented or if a user adds a comment as the last line.

Original user query
```
select a, b , c 
from dual
group by 1,
         2
      --,3
```
Before
```
select a, b , c 
from dual
group by 1,
         2
      --,3;  <-- Non-terminated statement error
```
After
```
select a, b , c 
from dual
group by 1,
         2
      --,3
         ; 
```
* Having `;` on a new line is a valid Presto SQL. 
* FYI, if a user query has a comment on the last line and a `;` then we don't touch it. And it will still produce a `Non-terminated statement error`. The solution there is to fix the SQL itself. 