### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
* Remove the deprecated `sudo:false` flag from .travis.yml.
    * More info [here](https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments)
* Fixes issue [52](https://github.com/Netflix/pygenie/issues/52).
