### PR TITLE
Travis CI: Add more flake8 test and add Py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
+os: linux
+dist: focal
 language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.8"
 install: pip install flake8 tox-travis
-before_script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: tox
 deploy:
   provider: pypi
-  user: nflxgenie
+  username: nflxgenie
   password:
     secure: CXe2NwhxyfgG6Biphj6WfF86NXcIpoVz7BJGaVmM0zaaHf6lBlgwG106rqRMLF+fFMIJ3ISI4y47/4NLBquXwAwOZ0pUTfKYwt08BnB53Bu3q/671RmCoZUsqpG9CwBM18t/Ef9Q82H8u55yPaSEzbsKwAzoaHK1QgDgpDHrtXh1f+Y3XkfHYZBlBvujrz139v0XMy2rEO0kJu84fFil7m8NZ+s5JD+nbogmA/xo1L4/SW3Wt3qcYmGNKWqvl2wnFlpQocnWxFJJUH89RX3juZoO+3bnPKhzwJQKsC683EL9102Gus7eMCv4LdS18sRfnLJuHl7ZxjSWTeMy5quvZywcXwWxKYWMr8N0mRFNe36onveOgc9ATCRy+KKQx0Rhf+FAzuWyW5ZAQZHN7Qs4gzJgzUPOusOk92KGdlP2mLfKF+6soYb0IrlstZFoinXhUR9KRMYbLDdAy6cAthLUNZkxjlceH9Or87YO8wDCItP3uIpXm4z8RbPQ/fE5IYk1a0nqUUFrtU68Rx3KDX/gxj8CduLgMxwnXd9YAjd4OmmL/6zzqAn3eq24CUu00Byir7t3CidvPbASNX2DsVoF/qQozk97VZ/fANc38Zu6DP/o5oMYj9EFPhubd3YBVqUxXDTCL9HDtMiw4y3lAI/urHChCzZqFxOI+jVwJ7rEW5c=
   distributions: "sdist bdist_wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 jobs:
   allow_failures:
     python: "3.8"
-install: pip install --upgrade flake8 tox-travis
+install: pip install flake8 tox-travis
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: tox
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-install: pip install -- upgrade flake8 tox tox-travis
+install: pip install --upgrade flake8 tox tox-travis
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: tox
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
   - "3.8"
+jobs:
+  allow_failures:
+    python: "3.8"
 install: pip install --upgrade flake8 tox-travis
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
   - "3.8"
-install: pip install flake8 tox-travis
+install: pip install -- upgrade flake8 tox tox-travis
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: tox
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ language: python
 python:
   - "2.7"
   - "3.6"
-  - "3.7"
   - "3.8"
-install: pip install --upgrade flake8 responses tox-travis
+install: pip install --upgrade flake8 tox-travis
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: tox
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-install: pip install --upgrade flake8 tox tox-travis
+install: pip install --upgrade flake8 responses tox-travis
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: tox
 deploy:

--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -88,7 +88,7 @@ class Repr(object):
             results = list()
 
             redact_hint=None
-            if len(args) > 0 and len(args) % 2 is 0 and is_str(args[0]):
+            if len(args) > 0 and len(args) % 2 == 0 and is_str(args[0]):
                 redact_hint = args[0]
 
             for i, arg in enumerate([convert_to_unicode(a) for a in args]):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py{27,36,37,38}
 
 [testenv]
 # disable Python's hash randomization for tests that stringify dicts, etc
@@ -9,4 +9,4 @@ commands = nosetests
 deps =
     mock
     nose
-    responses == 0.5.1
+    responses


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.