### PR TITLE
Replace is with == and fix SyntaxWarning for python3.10+

### DIFF
--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -88,7 +88,7 @@ class Repr(object):
             results = list()
 
             redact_hint=None
-            if len(args) > 0 and len(args) % 2 is 0 and is_str(args[0]):
+            if len(args) > 0 and len(args) % 2 == 0 and is_str(args[0]):
                 redact_hint = args[0]
 
             for i, arg in enumerate([convert_to_unicode(a) for a in args]):


### PR DESCRIPTION
- Fixes the following warning.

```
/apps/python3.10/lib/python3.10/site-packages/pygenie/jobs/core.py:91: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(args) > 0 and len(args) % 2 is 0 and is_str(args[0]):
```

- More details on python language side can found[here](https://bugs.python.org/issue34850)