### PR TITLE
Replace pkg_resources with importlib_metadata

### DIFF
--- a/pygenie/__init__.py
+++ b/pygenie/__init__.py
@@ -26,9 +26,9 @@ Run Job Example:
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import pkg_resources
+from importlib_metadata import version
 
-__version__ = pkg_resources.get_distribution('nflx-genie-client').version
+__version__ = version('nflx-genie-client')
 
 from .jobs.utils import (generate_job_id,
                          reattach_job)

--- a/pygenie/utils.py
+++ b/pygenie/utils.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import json
 import logging
-import pkg_resources
 import re
 import six
 import socket
@@ -20,6 +19,7 @@ import time
 import uuid
 
 from functools import wraps
+from importlib_metadata import version
 
 import requests
 
@@ -36,7 +36,7 @@ USER_AGENT_HEADER = {
     'user-agent': '/'.join([
         socket.getfqdn(),
         'nflx-genie-client',
-        pkg_resources.get_distribution('nflx-genie-client').version
+        version('nflx-genie-client')
     ])
 }
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
         "pyconfigurator",
         "python-dateutil >= 2.4",
         "requests",
-        "six"
+        "six",
+        "importlib-metadata",
     ],
     setup_requires=['setupmeta'],
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
`pkg_resources` is deprecated, and it's better to replace it rather than keep `setuptools` as a runtime requirement.