### PR TITLE
Add override_existing execute option

### DIFF
--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -482,6 +482,9 @@ class GenieJob(object):
 
         Returns:
             :py:class:`RunningJob`: A running job object.
+
+        Raises:
+            ValueError: If `override_existing` is True without `force` being True.
         """
 
         if not force and override_existing:

--- a/pygenie/jobs/core.py
+++ b/pygenie/jobs/core.py
@@ -484,6 +484,9 @@ class GenieJob(object):
             :py:class:`RunningJob`: A running job object.
         """
 
+        if not force and override_existing:
+            raise ValueError("override_existing cannot be True without force=True")
+
         if catch_signal:
             import signal
             import sys
@@ -502,15 +505,15 @@ class GenieJob(object):
             signal.signal(signal.SIGTERM, sig_handler)
             signal.signal(signal.SIGABRT, sig_handler)
 
-        if retry or force or override_existing:
+        if retry or force:
             uid = self._job_id
             try:
                 # below uid should be uid of job with one of following status:
                 #     - new
                 #     - (if override_existing=False) running
-                #     - (if force=False and override_existing=False) successful
+                #     - (if force=False) successful
                 uid = generate_job_id(uid,
-                                      return_success=not (force or override_existing),
+                                      return_success=not force,
                                       override_existing=override_existing,
                                       conf=self._conf)
                 # new uid will raise and be handled in the except block

--- a/pygenie/jobs/utils.py
+++ b/pygenie/jobs/utils.py
@@ -193,6 +193,20 @@ def generate_job_id(job_id, return_success=True, override_existing=False, conf=N
     If return_success is False and override_existing is True, will continue to
     generate an id until the generated id is completely new and kill the
     discovered running job(s)
+
+    Args:
+        job_id (str): The initial job id to start the generation process.
+        return_success (bool, optional): If True, allows returning an id for a successful job.
+            Defaults to True.
+        override_existing (bool, optional): If True, will terminate any running jobs
+            found during id generation. Defaults to False.
+        conf (optional): Configuration settings to be used during job reattachment. Defaults to None.
+
+    Returns:
+        str: A valid job id that meets the specified conditions.
+
+    Raises:
+        ValueError: If both `return_success` and `override_existing` are set to True.
     """
 
     if return_success and override_existing:

--- a/pygenie/jobs/utils.py
+++ b/pygenie/jobs/utils.py
@@ -190,9 +190,13 @@ def generate_job_id(job_id, return_success=True, override_existing=False, conf=N
     1) the generated id is for a job that is running
     2) the generated id is completely new
 
-    If override_existing is True, will continue to generate an id until
-    the generated id is completely new and kill the discovered running job(s)
+    If return_success is False and override_existing is True, will continue to
+    generate an id until the generated id is completely new and kill the
+    discovered running job(s)
     """
+
+    if return_success and override_existing:
+        raise ValueError("return_success and override_existing cannot both be True")
 
     while True:
         try:
@@ -200,7 +204,7 @@ def generate_job_id(job_id, return_success=True, override_existing=False, conf=N
             logger.debug("job id '%s' exists with status '%s'",
                          job_id,
                          running_job.status)
-            if override_existing:
+            if not return_success and override_existing:
                 if not running_job.is_done:
                     logger.warning("killing job id %s", job_id)
                     response = running_job.kill()

--- a/tests/job_tests/test_geniejob.py
+++ b/tests/job_tests/test_geniejob.py
@@ -325,6 +325,18 @@ class TestingJobExecute(unittest.TestCase):
         exec_job.assert_called_once_with(job)
         assert new_job_id == job._job_id
 
+    def test_job_execute_raises_error_when_override_without_force(self):
+        """Testing job execution when override_existing is True but force is False."""
+
+        with self.assertRaises(ValueError) as context:
+            pygenie.jobs.HiveJob() \
+                .job_id('exec') \
+                .genie_username('exectester') \
+                .script('select * from db.table') \
+                .execute(force=False, override_existing=True)
+
+        self.assertEqual(str(context.exception), "override_existing cannot be True without force=True")
+
     @patch('pygenie.jobs.core.reattach_job')
     @patch('pygenie.jobs.core.generate_job_id')
     @patch('pygenie.jobs.core.execute_job')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import unittest
 from socket import timeout
 
 import pytest
-from mock import patch
+from mock import patch, MagicMock
 from requests.exceptions import ConnectionError, Timeout
 
 from pygenie.exceptions import GenieHTTPError, GenieJobNotFoundError
@@ -393,6 +393,49 @@ class TestGeneratingJobId(unittest.TestCase):
         ]
 
         assert job_id+'-4' == generate_job_id(job_id, return_success=False)
+
+    @patch('pygenie.jobs.utils.reattach_job')
+    def test_gen_job_id_with_override_existing_true(self, mock_reattach_job):
+        """Test generating job id with overriding existing job set to True."""
+
+        job_id = 'override-existing-true'
+
+        mock_reattach_job.side_effect = [
+            FakeRunningJob(job_id=job_id, status='FAILED'),
+            FakeRunningJob(job_id=job_id + '-1', status='KILLED'),
+            FakeRunningJob(job_id=job_id + '-2', status='SUCCEEDED'),
+            FakeRunningJob(job_id=job_id + '-3', status='KILLED'),
+            FakeRunningJob(job_id=job_id + '-4', status='FAILED'),
+            FakeRunningJob(job_id=job_id + '-5', status='SUCCEEDED'),
+            GenieJobNotFoundError
+        ]
+
+        assert job_id + '-6' == generate_job_id(job_id, override_existing=True)
+
+    @patch('pygenie.jobs.utils.reattach_job')
+    def test_gen_job_id_with_override_existing_true_with_running(self, mock_reattach_job):
+        """Test generating job id with overriding existing job set to True with a job that is running."""
+
+        job_id = 'override-existing-true-running'
+
+        mock_running_job = MagicMock()
+        mock_running_job.job_id = job_id + '-5'
+        mock_running_job.status = 'RUNNING'
+        mock_running_job.is_done = False
+        mock_running_job.kill.return_value = fake_response({}, 200)
+
+        mock_reattach_job.side_effect = [
+            FakeRunningJob(job_id=job_id, status='FAILED'),
+            FakeRunningJob(job_id=job_id + '-1', status='KILLED'),
+            FakeRunningJob(job_id=job_id + '-2', status='SUCCEEDED'),
+            FakeRunningJob(job_id=job_id + '-3', status='KILLED'),
+            FakeRunningJob(job_id=job_id + '-4', status='FAILED'),
+            mock_running_job,
+            GenieJobNotFoundError
+        ]
+
+        assert job_id + '-6' == generate_job_id(job_id, override_existing=True)
+        mock_running_job.kill.assert_called_once()
 
     def test_is_file_for_valid_s3path(self):
         path = 's3://root/myfile'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -394,11 +394,22 @@ class TestGeneratingJobId(unittest.TestCase):
 
         assert job_id+'-4' == generate_job_id(job_id, return_success=False)
 
-    @patch('pygenie.jobs.utils.reattach_job')
-    def test_gen_job_id_with_override_existing_true(self, mock_reattach_job):
-        """Test generating job id with overriding existing job set to True."""
+    def test_gen_job_id_with_return_success_true_override_existing_true(self):
+        """Test generating job id with both returning successful job and overriding existing job set to True."""
 
-        job_id = 'override-existing-true'
+        job_id = 'return-successful-true-override-existing-true'
+
+        with self.assertRaises(ValueError) as context:
+            generate_job_id(job_id, return_success=True, override_existing=True)
+
+        self.assertEqual(str(context.exception), "return_success and override_existing cannot both be True")
+
+    @patch('pygenie.jobs.utils.reattach_job')
+    def test_gen_job_id_with_return_success_false_override_existing_true(self, mock_reattach_job):
+        """Test generating job id with returning successful job set to False and
+        overriding existing job set to True."""
+
+        job_id = 'return-successful-false-override-existing-true'
 
         mock_reattach_job.side_effect = [
             FakeRunningJob(job_id=job_id, status='FAILED'),
@@ -410,13 +421,14 @@ class TestGeneratingJobId(unittest.TestCase):
             GenieJobNotFoundError
         ]
 
-        assert job_id + '-6' == generate_job_id(job_id, override_existing=True)
+        assert job_id + '-6' == generate_job_id(job_id, return_success=False, override_existing=True)
 
     @patch('pygenie.jobs.utils.reattach_job')
-    def test_gen_job_id_with_override_existing_true_with_running(self, mock_reattach_job):
-        """Test generating job id with overriding existing job set to True with a job that is running."""
+    def test_gen_job_id_with_return_success_false_override_existing_true_with_running(self, mock_reattach_job):
+        """Test generating job id with returning successful job set to False and
+        overriding existing job set to True with a job that is running."""
 
-        job_id = 'override-existing-true-running'
+        job_id = 'return-successful-false-override-existing-true-running'
 
         mock_running_job = MagicMock()
         mock_running_job.job_id = job_id + '-5'
@@ -434,7 +446,7 @@ class TestGeneratingJobId(unittest.TestCase):
             GenieJobNotFoundError
         ]
 
-        assert job_id + '-6' == generate_job_id(job_id, override_existing=True)
+        assert job_id + '-6' == generate_job_id(job_id, return_success=False, override_existing=True)
         mock_running_job.kill.assert_called_once()
 
     def test_is_file_for_valid_s3path(self):


### PR DESCRIPTION
This PR introduces a new execute option, `override_existing`, to enhance job retry. When `force` and `override_existing` are both set to `True`, any existing job retries will be overridden, and a new job will be created. Additionally, any previously running executions will be terminated.

This change provides the scheduler with the capability to create a completely new job during retries and ensure that no previous retries are running concurrently.