### PR TITLE
Remove `importlib-metadata` and only support python>=3.9

### DIFF
--- a/pygenie/__init__.py
+++ b/pygenie/__init__.py
@@ -26,7 +26,7 @@ Run Job Example:
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from importlib_metadata import version
+from importlib.metadata import version
 
 __version__ = version('nflx-genie-client')
 

--- a/pygenie/utils.py
+++ b/pygenie/utils.py
@@ -19,7 +19,7 @@ import time
 import uuid
 
 from functools import wraps
-from importlib_metadata import version
+from importlib.metadata import version
 
 import requests
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     license='Apache 2.0',
     description='Genie Python Client.',
     long_description=long_description,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=[
         "decorator",
         "multipledispatch",

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     license='Apache 2.0',
     description='Genie Python Client.',
     long_description=long_description,
+    python_requires='>=3.8',
     install_requires=[
         "decorator",
         "multipledispatch",
@@ -48,7 +49,6 @@ setup(
         "python-dateutil >= 2.4",
         "requests",
         "six",
-        "importlib-metadata",
     ],
     setup_requires=['setupmeta'],
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The `importlib.metadata` package is in the stdlib for python>=3.8. Since pygenie's classifiers say it only supports python>=3.9, the backport package is unnecessary. I added an explicit `python_requires` in the setup.py to ensure the package only runs on the intended versions and then removed the `importlib-metadata` package.